### PR TITLE
build(deps): bump js-yaml to 4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3005,9 +3005,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Что

- `js-yaml` `4.2.0 → 4.3.0` — закрывает Dependabot-алерт #65 (high): quadratic CPU consumption через YAML merge-key chains.
- `astro` `7.0.0 → 7.1.0` в lockfile — приводит `node_modules`/lock в соответствие с `package.json` (`^7.1.0` из #198/#199).

## Заодно

Закрыты как устаревшие 13 Dependabot-алертов по Pillow (#66–78) — они висели на `uv.lock`, удалённом при миграции MkDocs → Astro (0361d41). Pillow в проекте больше не используется.

## Проверка

- `npm run build` — ✓ 9 страниц собрано.